### PR TITLE
Add multi struct wrapper for command with counter for repeated commands

### DIFF
--- a/brainfuck/commands.go
+++ b/brainfuck/commands.go
@@ -36,7 +36,7 @@ func (output) execute(b *buffer) {
 }
 
 type loop struct {
-	cmds []command
+	cmds []multi
 }
 
 func (l loop) execute(b *buffer) {
@@ -45,4 +45,19 @@ func (l loop) execute(b *buffer) {
 			c.execute(b)
 		}
 	}
+}
+
+type multi struct {
+	cmd   command
+	count int
+}
+
+func (m multi) execute(b *buffer) {
+	for ; m.count > 0; m.count-- {
+		m.cmd.execute(b)
+	}
+}
+
+func newMulti(cmd command) multi {
+	return multi{cmd, 1}
 }

--- a/brainfuck/commands_test.go
+++ b/brainfuck/commands_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLoop_execute(t *testing.T) {
 	type fields struct {
-		cmds []command
+		cmds []multi
 	}
 	type args struct {
 		buffer *buffer
@@ -20,14 +20,14 @@ func TestLoop_execute(t *testing.T) {
 	}{
 		{
 			"skips executing commands if buffer current cell value is zero",
-			fields{[]command{forward{}, increment{}}},
+			fields{[]multi{newMulti(forward{}), newMulti(increment{})}},
 			args{buffer: newBuffer()},
 			*newBuffer(),
 		},
 		{
 			"executes all commands if buffer current cell value is non-zero",
-			fields{[]command{
-				forward{}, increment{}, increment{}, backward{}, decrement{},
+			fields{[]multi{
+				newMulti(forward{}), newMulti(increment{}), newMulti(increment{}), newMulti(backward{}), newMulti(decrement{}),
 			}},
 			args{buffer: &buffer{[]byte{1}, 0}},
 			buffer{[]byte{0, 2}, 0},


### PR DESCRIPTION
Changes the "compilation"/"parsing" step, so that consecutive identical commands are merged into a new struct called `multi`, which stores the command itself, as well as the repetition counter. Thus, `compile` no longer returns a `[]command`, but a `[]multi`.