### PR TITLE
Add bit shift operator

### DIFF
--- a/brainfuck/commands.go
+++ b/brainfuck/commands.go
@@ -66,3 +66,21 @@ func (l loop) execute(b *buffer) {
 		}
 	}
 }
+
+/*
+	Left shift current buffer value's bits for one step ('{' operator).
+*/
+type leftshift struct{}
+
+func (leftshift) execute(b *buffer) {
+	b.cells[b.ptr] <<= 1
+}
+
+/*
+	Right shift current buffer value's bits for one step ('}' operator).
+*/
+type rightshift struct{}
+
+func (rightshift) execute(b *buffer) {
+	b.cells[b.ptr] >>= 1
+}

--- a/brainfuck/commands.go
+++ b/brainfuck/commands.go
@@ -68,7 +68,7 @@ func (l loop) execute(b *buffer) {
 }
 
 /*
-	Left shift current buffer value's bits for one step ('{' operator).
+	leftshift defines an execute method that left shifts current buffer value's bits for one step ('{' operator).
 */
 type leftshift struct{}
 
@@ -77,7 +77,7 @@ func (leftshift) execute(b *buffer) {
 }
 
 /*
-	Right shift current buffer value's bits for one step ('}' operator).
+	rightshift defines an execute method that right shift current buffer value's bits for one step ('}' operator).
 */
 type rightshift struct{}
 

--- a/brainfuck/commands_test.go
+++ b/brainfuck/commands_test.go
@@ -32,6 +32,14 @@ func TestLoop_execute(t *testing.T) {
 			args{buffer: &buffer{[]byte{1}, 0}},
 			buffer{[]byte{0, 2}, 0},
 		},
+		{
+			"executes bit shift commands",
+			fields{[]command{
+				leftshift{}, leftshift{}, forward{}, rightshift{},
+			}},
+			args{buffer: &buffer{[]byte{1, 1}, 0}},
+			buffer{[]byte{4, 0}, 1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/brainfuck/interpreter.go
+++ b/brainfuck/interpreter.go
@@ -75,6 +75,10 @@ func addCommand(char rune, c *commandStorage) {
 		c.add(decrement{})
 	case '.':
 		c.add(output{})
+	case '{':
+		c.add(leftshift{})
+	case '}':
+		c.add(rightshift{})
 	case '[':
 		c.loop = append(c.loop, []command{})
 	case ']':

--- a/brainfuck/interpreter_test.go
+++ b/brainfuck/interpreter_test.go
@@ -11,6 +11,7 @@ func TestInterpret(t *testing.T) {
 		args args
 	}{
 		{"hello world", args{"++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."}},
+		{"print @ [space] @ [new line]", args{"++++++>+<[>{<-]>.}.{.}}}}+{."}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Two new symbols (operators) added into the Brainfuck language, namely:
• `{` – left bit shift for 1 bit
• `}` – right bit shift for 1 bit

Simple test that prints '@ @\n' added.